### PR TITLE
fix: Redirect oomusou.io to old-oomusou.goodjack.tw

### DIFF
--- a/html/jsa/softwareEngineering.html
+++ b/html/jsa/softwareEngineering.html
@@ -113,7 +113,7 @@
 <p>該次的測試網址為 <a href="https://travis-ci.org/ccckmit/mdo/builds/209273266">https://travis-ci.org/ccckmit/mdo/builds/209273266</a> 。</p>
 <p>相關參考：</p>
 <ul>
-<li><a href="http://oomusou.io/ci/travis-ci-setup/">如何使用Travis CI自動測試?</a> (讚！)</li>
+<li><a href="https://old-oomusou.goodjack.tw/ci/travis-ci-setup/">如何使用Travis CI自動測試?</a> (讚！)</li>
 <li><a href="http://www.dotblogs.com.tw/hatelove/archive/2011/12/25/introducing-continuous-integration.aspx">持續整合 (Continuous integration, CI) 簡介</a></li>
 </ul>
 <pre><code>CI就像鍵盤上的enter鍵這麼自然，在每一次的變更，CI server都幫我們整合所有相關的服務，並將結果回饋給整個團隊，就像隨時隨地都有一個醫生在幫系統作全身健康檢查。

--- a/md/jsa/softwareEngineering.md
+++ b/md/jsa/softwareEngineering.md
@@ -88,7 +88,7 @@ NVM 則可以用來選擇 node 與套件的環境版本！
 
 相關參考：
 
-* [如何使用Travis CI自動測試?](http://oomusou.io/ci/travis-ci-setup/) (讚！)
+* [如何使用Travis CI自動測試?](https://old-oomusou.goodjack.tw/ci/travis-ci-setup/) (讚！)
 * [持續整合 (Continuous integration, CI) 簡介](http://www.dotblogs.com.tw/hatelove/archive/2011/12/25/introducing-continuous-integration.aspx)
 
 ```


### PR DESCRIPTION
舊的 oomusou.io 文章已經轉移至 old-oomusou.goodjack.tw